### PR TITLE
Add Amplifier Profiles for Profiler plugin

### DIFF
--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -2257,6 +2257,9 @@ class FilesList(JsonRequestHandler):
 
         elif filetype == "sfz":
             return ("SFZ Instruments", (".sfz",))
+        
+        elif filetype == "tapf":
+            return ("Amplifier Profiles", (".tapf",))
 
         else:
             return (None, ())


### PR DESCRIPTION
I am busy uploading my profiler plugin to patchstorage, but it requires a filetype addition.